### PR TITLE
Fix: voice cloning with 'audio prompt' and associated text.

### DIFF
--- a/cli/SparkTTS.py
+++ b/cli/SparkTTS.py
@@ -91,6 +91,7 @@ class SparkTTS:
                 "<|end_global_token|>",
                 "<|start_semantic_token|>",
                 semantic_tokens,
+                "<|end_semantic_token|>",
             ]
         else:
             inputs = [


### PR DESCRIPTION
The voice cloning with text is broken due to a missing end token in the audio and audio text prompt input tokenization stage. This commit fixes this and makes voice cloning work as expected.